### PR TITLE
PR: Duck DNS 서버 추가

### DIFF
--- a/.ebextensions/ssl.config
+++ b/.ebextensions/ssl.config
@@ -1,0 +1,17 @@
+container_commands:
+  01_install_awscli:
+    command: |
+      if ! command -v aws &> /dev/null; then
+        echo "CLI 설치"
+        curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip"
+        unzip awscliv2.zip
+        sudo ./aws/install
+      fi
+
+  02_download_ssl_certificates:
+    command: |
+      mkdir -p /etc/nginx/ssl
+      aws s3 sync s3://sprout-ssl-cert /etc/nginx/ssl/
+
+  03_restart_nginx:
+    command: sudo service nginx restart

--- a/.platform/nginx/nginx.conf
+++ b/.platform/nginx/nginx.conf
@@ -82,8 +82,8 @@ http {
       listen 443 ssl;
       server_name dev-sprout.duckdns.org www.dev-sprout.duckdns.org;
 
-      ssl_certificate /etc/letsencrypt/live/dev-sprout.duckdns.org/fullchain.pem;
-      ssl_certificate_key /etc/letsencrypt/live/dev-sprout.duckdns.org/privkey.pem;
+      ssl_certificate /etc/nginx/ssl/fullchain.pem;
+      ssl_certificate_key /etc/nginx/ssl/privkey.pem;
 
       ssl_protocols TLSv1.2 TLSv1.3;
       ssl_ciphers HIGH:!aNULL:!MD5;


### PR DESCRIPTION
### 접속 도메인 : https://dev-sprout.duckdns.org/

## SSL 관련 설정
> .ebextensions/ssl.config 여기에 S3에서 SSL 파일 읽어오는 배치 존재
> 해당 파일은 nginx/ssl/ 아래로 저장
> nginx에서 https값 읽는 부분 :
>>    ssl_certificate /etc/nginx/ssl/fullchain.pem;
>>    ssl_certificate_key /etc/nginx/ssl/privkey.pem;