### PR TITLE
fix: 댓글 작성 타입 반환 (공지인지 라운지인지)

### DIFF
--- a/src/main/kotlin/io/sprout/api/comment/service/CommentService.kt
+++ b/src/main/kotlin/io/sprout/api/comment/service/CommentService.kt
@@ -6,6 +6,7 @@ import io.sprout.api.comment.dto.CommentResponseDto
 import io.sprout.api.comment.dto.commentUserDto
 import io.sprout.api.comment.repository.CommentRepository
 import io.sprout.api.notification.entity.NotificationDto
+import io.sprout.api.post.entities.PostType
 import io.sprout.api.post.repository.PostRepository
 import io.sprout.api.post.service.PostService
 import io.sprout.api.sse.service.SseService
@@ -31,6 +32,8 @@ class CommentService(
         val post = postRepository.findById(dto.postId)
                 .orElseThrow { EntityNotFoundException("게시글을 찾을 수 없음") }
 
+        val isNotice = if (post.postType == PostType.NOTICE) 3 else 2
+
         val comment = CommentEntity(
                 content = dto.content,
                 user = user,
@@ -41,9 +44,9 @@ class CommentService(
         val savedComment = commentRepository.save(comment)
 
         val dtodata = NotificationDto(
-            fromId = post.clientId,
-            userId = clientID,
-            type = 3,
+            fromId = clientID,
+            userId = post.clientId,
+            type = isNotice.toLong(),
             url = "${post.id}",
             content = postService.getPostTitle(post.id),
             NotiType = 5,


### PR DESCRIPTION
- 라운지, 공지사항 댓글을 작성하면 댓글 작성자 알림에 추가됨 → 라운지, 공지사항 작성자에게 알림이 추가되도록 수정 필요
- 라운지 게시물에 댓글 작성 시 공지사항 type으로 분류됨  → type 2번으로 수정 필요
   -> 기존 type 12형으로 변환