### PR TITLE
feat: Logout API Controller 추가

### DIFF
--- a/src/main/kotlin/io/sprout/api/auth/filter/JwtFilter.kt
+++ b/src/main/kotlin/io/sprout/api/auth/filter/JwtFilter.kt
@@ -64,6 +64,7 @@ class JwtFilter(
             "/api/user/verification/**",
             "/api/notifications/admin",
             "/api/aws/**",
+            "/api/sproutLogout",
         )
         val path = request.requestURI
         logger.info ( "Request Path: $path" )

--- a/src/main/kotlin/io/sprout/api/user/controller/LogoutController.kt
+++ b/src/main/kotlin/io/sprout/api/user/controller/LogoutController.kt
@@ -1,0 +1,19 @@
+package io.sprout.api.user.controller
+
+import io.sprout.api.utils.CookieUtils
+import jakarta.servlet.http.HttpServletResponse
+import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
+
+@RestController
+@RequestMapping("/sproutLogout")
+class LogoutController {
+
+    @GetMapping
+    fun logoutHandle(response: HttpServletResponse): ResponseEntity<String> {
+        CookieUtils.addCookie(response, "refresh_token", "", 0)
+        return ResponseEntity.ok("로그아웃 완료되었습니다.")
+    }
+}


### PR DESCRIPTION
SSE 연동은 하지 않고, 우선 쿠키만 삭제하는 API를 개발했습니다.  
  
우선은 그렇습니다.  
sproutLogout으로 만들었고, Cookie Util 코드가 남아있길래
RefreshToken의 유효 시간을 0초로 만들어 업데이트합니다.