### PR TITLE
PR: 조회수 관련 API 수정사항

### DIFF
--- a/src/main/kotlin/io/sprout/api/mypage/dto/GetPostResponseDto.kt
+++ b/src/main/kotlin/io/sprout/api/mypage/dto/GetPostResponseDto.kt
@@ -18,6 +18,7 @@ data class GetPostResponseDto (
     val id: Long,
     val writer: writerDto,
     val postId: Long,
+    val linkedId: Long,
     val title: String,
     val postType: PostType,
     val content: String,

--- a/src/main/kotlin/io/sprout/api/mypage/dto/PostCommentDto.kt
+++ b/src/main/kotlin/io/sprout/api/mypage/dto/PostCommentDto.kt
@@ -6,6 +6,7 @@ data class PostCommentDto(
         val commentId: Long,
         val userNickname: String,
         val postId: Long,
+        val linkedId: Long,
         val content: String,
         val createdAt: LocalDateTime,
         val postType: String,

--- a/src/main/kotlin/io/sprout/api/mypage/service/MypageService.kt
+++ b/src/main/kotlin/io/sprout/api/mypage/service/MypageService.kt
@@ -271,14 +271,19 @@ class MypageService(
                     )
 
                     var projectType = ""
-
+                    var linkedIdData: Long = 0
                     val postData = when (post) {
-                        is NoticeDetailResponseDto -> PostInfoDto(post.title, post.content, PostType.NOTICE)
+                        is NoticeDetailResponseDto -> {
+                            linkedIdData = post.id
+                            PostInfoDto(post.title, post.content, PostType.NOTICE)
+                        }
                         is ProjectDetailResponseDto -> {
+                            linkedIdData = post.id
                             projectType = post.pType.toString()
                             PostInfoDto(post.title, post.description, PostType.PROJECT)
                         }
                         is MealPostDto.MealPostDetailResponse -> {
+                            linkedIdData = post.mealPostId
                             PostInfoDto(post.title, "", PostType.MEAL)
                         }
                         else -> return@mapNotNull null
@@ -288,6 +293,7 @@ class MypageService(
                         id = it.id,
                         writer = writer,
                         postId = it.postId,
+                        linkedId = linkedIdData,
                         title = postData.title,
                         postType = postData.postType,
                         content = postData.content,

--- a/src/main/kotlin/io/sprout/api/mypage/service/MypageService.kt
+++ b/src/main/kotlin/io/sprout/api/mypage/service/MypageService.kt
@@ -184,6 +184,7 @@ class MypageService(
                 commentId = it.id,
                 userNickname = it.user.nickname,
                 postId = postService.getPostByLinkedIdAndPostType(it.store.id, PostType.STORE).id,
+                linkedId = it.store.id,
                 content = it.review ?: "",
                 createdAt = it.createdAt,
                 postType = PostType.STORE.toString(),
@@ -192,15 +193,23 @@ class MypageService(
         }
 
         val postComments = comments.map {
+            var linkedIdData: Long = 0
             var projectType = ""
             val post = postService.getPostById(it.postId)
             val mPostType = when (post) {
-                is NoticeDetailResponseDto -> PostType.NOTICE
+                is NoticeDetailResponseDto -> {
+                    linkedIdData = post.id
+                    PostType.NOTICE
+                }
                 is ProjectDetailResponseDto -> {
+                    linkedIdData = post.id
                     projectType = post.pType.toString()
                     PostType.PROJECT
                 }
-                is MealPostDto.MealPostDetailResponse -> PostType.MEAL
+                is MealPostDto.MealPostDetailResponse -> {
+                    linkedIdData = post.mealPostId
+                    PostType.MEAL
+                }
                 else -> PostType.NOTICE
             }
 
@@ -208,6 +217,7 @@ class MypageService(
                 commentId = it.id,
                 userNickname = it.userInfo.nickname,
                 postId = it.postId,
+                linkedId = linkedIdData,
                 content = it.content,
                 createdAt = it.createAt,
                 postType = mPostType.toString(),

--- a/src/main/kotlin/io/sprout/api/post/controller/PostController.kt
+++ b/src/main/kotlin/io/sprout/api/post/controller/PostController.kt
@@ -144,4 +144,14 @@ class PostController(
         val linkedId = postService.getLinkedIdByPostId(postId)
         return ResponseEntity.ok(linkedId)
     }
+
+    @GetMapping("/{postId}/view")
+    @Operation(
+            summary = "게시글 조회수 카운트 증가용 API",
+            description = "특정 게시글의 조회수를 증가시킵니다."
+    )
+    fun increaseViewCount(@PathVariable postId: Long): ResponseEntity<Boolean> {
+        val result = postService.increaseViewCount(postId)
+        return ResponseEntity.ok(result)
+    }
 }

--- a/src/main/kotlin/io/sprout/api/post/service/PostService.kt
+++ b/src/main/kotlin/io/sprout/api/post/service/PostService.kt
@@ -9,6 +9,7 @@ import io.sprout.api.notice.service.NoticeService
 import io.sprout.api.notification.entity.NotificationDto
 import io.sprout.api.post.entities.PostEntity
 import io.sprout.api.post.entities.PostType
+import io.sprout.api.post.entities.PostType.*
 import io.sprout.api.post.repository.PostRepository
 import io.sprout.api.project.model.dto.ProjectRecruitmentRequestDto
 import io.sprout.api.project.model.entities.PType
@@ -45,7 +46,7 @@ class PostService(
             val notice = noticeService.createNotice(noticeRequestDto)
             val post = PostEntity(
                 clientId = clientId,
-                postType = PostType.NOTICE,
+                postType = NOTICE,
                 linkedId = notice.id
             )
 
@@ -86,7 +87,7 @@ class PostService(
             val projectId = projectService.postProjectAndGetId(projectDto)
             val post = PostEntity(
                 clientId = clientId,
-                postType = PostType.PROJECT,
+                postType = PROJECT,
                 linkedId = projectId
             )
 
@@ -109,7 +110,7 @@ class PostService(
             val mealId = mealPostService.createMealPostReturnId(dto)
             val post = PostEntity(
                 clientId = clientId,
-                postType = PostType.MEAL,
+                postType = MEAL,
                 linkedId = mealId
             )
 
@@ -132,20 +133,20 @@ class PostService(
                 .orElseThrow { EntityNotFoundException("게시글을 찾을 수 없습니다.") }
 
         return when (post.postType) {
-            PostType.NOTICE -> {
+            NOTICE -> {
                 val noticeId = post.linkedId
                 noticeService.getNoticeById(noticeId)
             }
-            PostType.PROJECT -> {
+            PROJECT -> {
                 val projectId = post.linkedId
                 projectService.findProjectDetailById(projectId)
                         ?: throw EntityNotFoundException("프로젝트를 찾을 수 없습니다. -> 공지는 원본 안 건드림")
             }
-            PostType.MEAL -> {
+            MEAL -> {
                 val mealId = post.linkedId
                 mealPostService.getMealPostDetail(mealId)
             }
-            PostType.STORE -> {
+            STORE -> {
                 val storeId = post.linkedId
                 storeService.getStoreDetail(storeId)
             }
@@ -162,11 +163,11 @@ class PostService(
             .orElseThrow { EntityNotFoundException("게시글을 찾을 수 없습니다.") }
 
         return when (post.postType) {
-            PostType.NOTICE -> {
+            NOTICE -> {
                 val noticeId = post.linkedId
                 noticeService.getNoticeById(noticeId).writer.userId
             }
-            PostType.PROJECT -> {
+            PROJECT -> {
                 val projectId = post.linkedId
                 projectService.findProjectDetailById(projectId)?.writerId
             }
@@ -184,7 +185,7 @@ class PostService(
 
         return posts.map { post ->
             when (post.postType) {
-                PostType.NOTICE -> {
+                NOTICE -> {
                     val noticeId = post.linkedId
                     val notice = noticeService.getNoticeById(noticeId)
                     if (compact) {
@@ -198,7 +199,7 @@ class PostService(
                         notice
                     }
                 }
-                PostType.PROJECT -> {
+                PROJECT -> {
                     val projectId = post.linkedId
                     val project = projectService.findProjectDetailById(projectId)
                             ?: throw EntityNotFoundException("프로젝트를 찾을 수 없습니다.")
@@ -213,7 +214,7 @@ class PostService(
                         project
                     }
                 }
-                PostType.MEAL -> {
+                MEAL -> {
                     val mealId = post.linkedId
                     val meal = mealPostService.getMealPostDetail(mealId)
 
@@ -237,7 +238,7 @@ class PostService(
 
         return try {
             when (post.postType) {
-                PostType.NOTICE -> {
+                NOTICE -> {
                     if (dto !is NoticeRequestDto) {
                         throw IllegalArgumentException("Notice DTO를 확인 해 주세요.")
                     }
@@ -245,7 +246,7 @@ class PostService(
                     true
                 }
 
-                PostType.PROJECT -> {
+                PROJECT -> {
                     if (dto !is ProjectRecruitmentRequestDto) {
                         throw IllegalArgumentException("Project DTO를 확인 해 주세요.")
                     }
@@ -253,7 +254,7 @@ class PostService(
                     true
                 }
 
-                PostType.MEAL -> {
+                MEAL -> {
                     if (dto !is MealPostDto.MealPostCreateRequest) {
                         throw IllegalArgumentException("Meal DTO를 확인 해 주세요.")
                     }
@@ -283,9 +284,9 @@ class PostService(
             }
 
             when (post.postType) {
-                PostType.PROJECT -> projectService.deleteProject(post.linkedId)
-                PostType.NOTICE -> noticeService.deleteNotice(post.linkedId)
-                PostType.MEAL -> mealPostService.deleteMealPost(post.linkedId)
+                PROJECT -> projectService.deleteProject(post.linkedId)
+                NOTICE -> noticeService.deleteNotice(post.linkedId)
+                MEAL -> mealPostService.deleteMealPost(post.linkedId)
                 else -> { }
             }
 
@@ -321,13 +322,13 @@ class PostService(
             .orElseThrow { EntityNotFoundException("존재하지 않는 게시글 ID: $postId") }
 
         when (post.postType) {
-            PostType.NOTICE -> {
+            NOTICE -> {
                 return noticeService.getNoticeById(post.linkedId).title
             }
-            PostType.PROJECT -> {
+            PROJECT -> {
                 return projectService.findProjectDetailById(post.linkedId)?.title ?: ""
             }
-            PostType.MEAL -> {
+            MEAL -> {
                 return mealPostService.getMealPostDetail(post.linkedId).title
             }
             else -> throw EntityNotFoundException("프로젝트를 찾을 수 없습니다. -> 공지는 원본 안 건드림")
@@ -369,6 +370,27 @@ class PostService(
      */
     fun getNoticesByUserIdFromParticipant(userId: Long): List<NoticeParticipantEntity> {
         return postRepository.findNoticesByUserIdFromParticipant(userId)
+    }
+
+    /**
+     * 글 조회수 증가 API
+     */
+    fun increaseViewCount(postId: Long): Boolean {
+        val post = postRepository.findById(postId)
+            .orElseThrow { EntityNotFoundException("게시글을 찾을 수 없습니다.") }
+
+        return when (post.postType) {
+            NOTICE -> {
+                val noticeId = post.linkedId
+                noticeService.increaseViewCount(noticeId)
+            }
+            PROJECT -> {
+                val projectId = post.linkedId
+                projectService.increaseViewCount(projectId)
+            }
+            MEAL -> false
+            STORE -> false
+        }
     }
 
 

--- a/src/main/kotlin/io/sprout/api/project/model/dto/ProjectSimpleResponseDto.kt
+++ b/src/main/kotlin/io/sprout/api/project/model/dto/ProjectSimpleResponseDto.kt
@@ -5,5 +5,6 @@ data class ProjectSimpleResponseDto(
     val title: String,
     val content: String,
     val userNickname: String,
-    val imgUrl: String
+    val imgUrl: String,
+    val postId: Long
 )

--- a/src/main/kotlin/io/sprout/api/project/repository/ProjectCustomRepositoryImpl.kt
+++ b/src/main/kotlin/io/sprout/api/project/repository/ProjectCustomRepositoryImpl.kt
@@ -4,6 +4,7 @@ import com.querydsl.core.BooleanBuilder
 import com.querydsl.core.group.GroupBy
 import com.querydsl.core.types.Projections
 import com.querydsl.jpa.impl.JPAQueryFactory
+import io.sprout.api.post.entities.PostType
 import io.sprout.api.post.entities.QPostEntity
 import io.sprout.api.project.model.dto.*
 import io.sprout.api.project.model.entities.*
@@ -18,6 +19,7 @@ import java.time.LocalDate
 class ProjectCustomRepositoryImpl(
     private val queryFactory: JPAQueryFactory
 ) : ProjectCustomRepository {
+    val post = QPostEntity.postEntity
 
     override fun filterProjects(
         filterRequest: ProjectFilterRequest,
@@ -122,12 +124,16 @@ class ProjectCustomRepositoryImpl(
                 project.title,
                 project.description,
                 user.nickname,
-                user.profileImageUrl
+                user.profileImageUrl,
+                post.id
             )
             .from(project)
             .join(project.writer, user)
+            .leftJoin(post)
+                .on(post.linkedId.eq(project.id).and(
+                    post.postType.eq(PostType.PROJECT)))
             .where(project.recruitmentEnd.between(
-                LocalDate.now(), 
+                LocalDate.now(),
                 LocalDate.now().plusDays(days)))
             .orderBy(project.recruitmentEnd.asc())
             .limit(size)
@@ -139,6 +145,7 @@ class ProjectCustomRepositoryImpl(
                     content = tuple.get(project.description) ?: "",
                     userNickname = tuple.get(user.nickname) ?: "Unknown",
                     imgUrl = tuple.get(user.profileImageUrl) ?: "null",
+                    postId = tuple.get(post.id) ?: throw IllegalArgumentException("Project is Not Equal (No Found Linked ID From POST)")
                 )
             }
     }


### PR DESCRIPTION
## 🚩 조회수 관련 API 수정사항

### 작업 내용
- **공지사항, 프로젝트의 view 카운트 증가 API 구분**
  - {postId}/view API 추가. PostId 입력 시 자동으로 project/notice 구분하여 증가함

- **comment, Scrap에서 linkedId 추가 전달 요청**
  - PostComment, PostScrap 내 LinkedId가 포함되어 전달됩니다.